### PR TITLE
fix: tmux.conf

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -49,7 +49,7 @@ bind K swap-pane -t {up-of} -d
 bind L swap-pane -t {right-of} -d
 
 bind - split-window -v
-bind \ split-window -h
+bind \\ split-window -h
 
 bind b set-option -g status
 


### PR DESCRIPTION
New tmux does not allow the backslash character in isolation. This
commit escapes it.

Signed-off-by: Connor McDermid <connor.mcdermid@mcvts.org>